### PR TITLE
Make print() calls compatible with python3

### DIFF
--- a/qjau.py
+++ b/qjau.py
@@ -41,7 +41,7 @@ parser.add_argument("-c", "--command", help="Command that you wish to run", narg
 args = parser.parse_args()
 
 if args.priority == None:
-    print "Error, priority argument required"
+    print ("Error, priority argument required")
     parser.print_help()
     sys.exit(-1)
 
@@ -50,17 +50,17 @@ if args.verbosity == None:
 
 
 if args.command == None:
-    print "Error, command argument required"
+    print ("Error, command argument required")
     parser.print_help()
     sys.exit(-1)
 
 if args.window == None:
-    print "Error, window size argument required"
+    print ("Error, window size argument required")
     parser.print_help()
     sys.exit(-1)
 
 if os.geteuid() != 0:
-    print "Error, set_sock_priority must be run as root."
+    print ("Error, set_sock_priority must be run as root.")
     sys.exit(-1)
 
 new_env = os.environ


### PR DESCRIPTION
I noticed that qjau.py uses python2-style print() calls, which when used with python3 resulted in:

```
./qjau.py  
  File "./qjau.py", line 53
    print "Error, command argument required"
                                           ^
SyntaxError: Missing parentheses in call to 'print'
```

Fixing the print() statements in a compatible way seemed better than hardcoding python2.
